### PR TITLE
Update install instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 url*
 data*
+ckan*
 data
 *.swp

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ It also requires curl.
 on Ubuntu 
 ```
 sudo apt-get install curl
-sudo apt-get install php5-curl
+sudo apt-get install php5-curl php5-cli
 ```
 
 


### PR DESCRIPTION
Updates to the install instructions so that the scripts will run from a clean Ubuntu install without generating trackable files after following the instructions.