### PR TITLE
Reduce wget read timeout

### DIFF
--- a/fetch_data.sh
+++ b/fetch_data.sh
@@ -41,12 +41,12 @@ do
     #                                 properly
     # -U sets our custom user agent, which allows sites to keep track of which
     #    robots are accessing them
-    # --read-timeout=180 times out if no data is sent for more than 10 seconds
+    # --read-timeout=30 times out if no data is sent for more than 30 seconds
     # --dns-timeout=10 times out if DNS information takes longer than 10 seconds
     # --connect-timeout=10 times out if establishing a connection takes longer
     #                      than 10 seconds
     # --tries=3 means a download is tried at most 3 times
-    wget --no-check-certificate --restrict-file-names=nocontrol --tries=3 --read-timeout=180 --dns-timeout=10 --connect-timeout=10 -U "IATI-Data-Snappshotter" "$url" -O data/`basename $f`/$package_name
+    wget --no-check-certificate --restrict-file-names=nocontrol --tries=3 --read-timeout=30 --dns-timeout=10 --connect-timeout=10 -U "IATI-Data-Snappshotter" "$url" -O data/`basename $f`/$package_name
     # Fetch the exitcode of the previous command
     exitcode=$?
     # If the exitcode is not zero (ie. there was an error), output to STDOUT


### PR DESCRIPTION
This reduces the wget read timeout to 30s from 180s. By doing this, a publisher with a server that doesn't respond correctly will have a far lower impact on the run time of the Registry Refresher.