### PR TITLE
Grab packages in (big) pages, rather than per org

### DIFF
--- a/grab_urls.php
+++ b/grab_urls.php
@@ -88,7 +88,9 @@ foreach ($groups as $group) {
         $result = api_request('action/package_search', array('fq'=>"organization:".$group, 'rows'=>1000000), "ckan/" . $group);
         foreach ($result->results as $package) {
             try {
-                $urls_string .= $package->name . ' ' . (string)$package->resources[0]->url . PHP_EOL;
+                if (count($package->resources) > 0) {
+                    $urls_string .= $package->name . ' ' . (string)$package->resources[0]->url . PHP_EOL;
+                }
             } catch (Exception $e) {
                 // Catch exceptions here to prevent one url from breaking an entire publisher
                 print 'Caught exception in '.$file.': ' . $e->getMessage();


### PR DESCRIPTION
I don’t know if this PR is of interest… But I wrote this code, so I thought I might as well send it in case it’s of use.

This greatly reduces the number of requests that grab_urls.php makes, so speeds up that part of the process. Of course, that’s not really the slow part of the process… But I don’t think this hurts.

This removes some exception handling that I don’t believe was doing anything useful (the inner try/catch does nothing; the outer try/catch masks a request failure that it’s quite important to know about.)