### PR TITLE
Retry on error

### DIFF
--- a/grab_urls.php
+++ b/grab_urls.php
@@ -44,10 +44,10 @@ function api_request($path, $data=null, $ckan_file=null) {
         'Content-Length: '.strlen($data_string))
     );
     
-    // Try up to 5 times if we get a 500 error.
+    // Try up to 5 times if we get a non- 200 status code.
     for ($i=0; $i<5; $i++) {
         $result = curl_exec($ch);
-        if (curl_getinfo($ch)['http_code'] == 500) {
+        if (curl_getinfo($ch)['http_code'] != 200) {
             // Wait a second before we retry
             sleep(1);
         }


### PR DESCRIPTION
Fixes #17.

**Explanation**
When making requests to the IATI Registry API, the registry refresher will pause and retry up to five times if it receives a response status code of 500 (Internal Server Error).

Currently, it is receiving response status codes of 503 (Service Unavailable). It should pause and retry in these cases, too, but it doesn’t. Ideally, it should retry if it receives a response status code that is anything other than 2xx (success).

This change checks for a response status code of 200 (OK). If it differs from that, it pauses and then retries.

---

This ought to help with https://github.com/IATI/ckanext-iati/issues/319